### PR TITLE
bower: add compatibility for AngularJS 1.3.x (and later)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
   	{"name": "Eugen Istoc"}
   ],
   "dependencies": {
-    "angular": "~1.2.0"
+    "angular": "^1.2.0"
   }
 } 


### PR DESCRIPTION
The filter seems to work fine on AngularJS 1.3.10. The current `bower.json` points to AngularJS 1.2.x only though. For a project using AngularJS 1.3.x this gives the `Unable to find a suitable version for angular, please choose one:`-dialog.

This PR adds support for AngularJS 1.3.x (and later, up to -but not including- 2.0.0).

Thanks for creating a `bower` package for this filter!
